### PR TITLE
MK-260 fix: Remove myAllClearReport from quickreply & Revert quick icons

### DIFF
--- a/APP(Android)/meerkat_fe/components/Chatroom/ChatroomAccessoryBar.tsx
+++ b/APP(Android)/meerkat_fe/components/Chatroom/ChatroomAccessoryBar.tsx
@@ -44,22 +44,22 @@ const ChatroomAccessoryBar = (props: ChatroomAccessoryBarProps) => {
         style={styles.item}
         onPress={() => props.onPressTemplate()}
       >
-        <MaterialCommunityIcons name="lightning-bolt" size={30} color="black" />
+        <MaterialCommunityIcons name="lightning-bolt" size={24} color="black" />
       </TouchableOpacity>
       <TouchableOpacity
         style={styles.item}
         // onPress={() => pickImageAsync(props.onSend)} // TODO: 나중에 image 시간되면 활성화.
       >
-        <MaterialIcons size={30} color="black" name="photo" />
+        <MaterialIcons size={24} color="black" name="photo" />
       </TouchableOpacity>
       <TouchableOpacity
         style={styles.item}
         onPress={props.onPressSuperiorSwitch}
       >
         {props.superiorOnly ? (
-          <AntDesign onPress={()=> props.onPressPin()} name="pushpin" size={30} color="black" />
+          <AntDesign onPress={()=> props.onPressPin()} name="pushpin" size={24} color="black" />
           ) : (
-          <AntDesign onPress={() => props.onPressPin()} name="pushpino" size={30} color="black" />
+          <AntDesign onPress={() => props.onPressPin()} name="pushpino" size={24} color="black" />
         )}
       </TouchableOpacity>
 
@@ -67,7 +67,7 @@ const ChatroomAccessoryBar = (props: ChatroomAccessoryBarProps) => {
         style={styles.item}
         onPress={()=>props.onPressAllClear()}
       >
-        <AntDesign name="notification" size={30} color="black" />
+        <AntDesign name="notification" size={24} color="black" />
       </TouchableOpacity>
     </View>
   );

--- a/APP(Android)/meerkat_fe/hooks/useMessage.tsx
+++ b/APP(Android)/meerkat_fe/hooks/useMessage.tsx
@@ -321,16 +321,11 @@ export const getAllClearQuickReply = (currentUserId: number, senderId: number)=>
   const quickReplies: QuickReplies = {
     type: 'radio',
     keepIt: true,
-    values: 
-      // (currentUserId === senderId)
-      // ? getAllClearStatisticsQuickReplyTemplate()
-      // : getAllClearReportQuickReplyTemplate()\
-
-[getAllClearStatisticsQuickReplyTemplate()[0], getAllClearReportQuickReplyTemplate()[0], getAllClearReportQuickReplyTemplate()[1]]
-// FIXME : 테스팅용. 추후에 위의 주석 친 것으로 바꾸기.
-
-    
-  }
+    values:
+      currentUserId === senderId
+        ? getAllClearStatisticsQuickReplyTemplate()
+        : getAllClearReportQuickReplyTemplate(),
+  };
   return quickReplies;
 }
 

--- a/APP(Android)/meerkat_fe/pages/ChatroomPage.tsx
+++ b/APP(Android)/meerkat_fe/pages/ChatroomPage.tsx
@@ -307,6 +307,11 @@ export default function ChatroomPage(props: RootStackScreenProps<'Chat'>) {
             onQuickReply={onQuickReply}
             renderQuickReplies={renderQuickReplies}
           />
+          <ChatroomTextInput
+            msgInput={msgInput}
+            setMsgInput={setMsgInput}
+            onSendTextMessage={text => sendNewMessageToServer(text)}
+          />
           <ChatroomAccessoryBar
             superiorOnly={superiorOnly}
             onPressTemplate={() => setTemplateVisible(true)}
@@ -332,11 +337,6 @@ export default function ChatroomPage(props: RootStackScreenProps<'Chat'>) {
             }}
             // onSend={onSendFromUser} // TODO: 로컬에서만 보내지니까 풀어줘도될듯? 테스팅해보고 풀어주기.
             onSend={() => {}}
-          />
-          <ChatroomTextInput
-            msgInput={msgInput}
-            setMsgInput={setMsgInput}
-            onSendTextMessage={text => sendNewMessageToServer(text)}
           />
         </View>
       </KeyboardAvoidingView>


### PR DESCRIPTION
quick reply에 작성자는 '통계 확인'만, 나머지는 '보고하기'탭만 보임.
quick icon을 revert해서 입력 창 아래로 내림.