### PR TITLE
MK-290 fix: AllClearStatistics unread count error

### DIFF
--- a/APP(Android)/meerkat_fe/pages/AllClearStatistics/AllClearStatistics.tsx
+++ b/APP(Android)/meerkat_fe/pages/AllClearStatistics/AllClearStatistics.tsx
@@ -173,7 +173,7 @@ export default function AllClearStatistics(props: AllClearStatisticsProps) {
                 { color: focusedIndex === 2 ? focusedColor : unfocusedColor },
               ]}
             >
-              {clears.length}
+              {unreads.length}
             </Text>
           </Pressable>
         </View>


### PR DESCRIPTION
unread count가 unreads.length가 아니라 allclear.length로 되어있었음.